### PR TITLE
Login signup pages (version 1)

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -11,11 +11,13 @@ import AddBeePage from './Pages/AddBeePage';
 import DeleteBeePage from './Pages/DeleteBeePage';
 import BeeDetailsPage from './Pages/BeeDetailsPage';
 import LoginPage from './Pages/LoginPage';
+import SignupPage from './Pages/SignupPage';
 
 const App = () => (
   <Router basename={process.env.PUBLIC_URL}>
     <Navbar />
     <LoginPage />
+    <SignupPage />
     <Routes>
       <Route exact path="/" element={<HomePage />} />
       <Route exact path="/:bee" element={<BeeDetailsPage />} />

--- a/src/App.js
+++ b/src/App.js
@@ -10,10 +10,12 @@ import ReservationsPage from './Pages/ReservationsPage';
 import AddBeePage from './Pages/AddBeePage';
 import DeleteBeePage from './Pages/DeleteBeePage';
 import BeeDetailsPage from './Pages/BeeDetailsPage';
+import LoginPage from './Pages/LoginPage';
 
 const App = () => (
   <Router basename={process.env.PUBLIC_URL}>
     <Navbar />
+    <LoginPage />
     <Routes>
       <Route exact path="/" element={<HomePage />} />
       <Route exact path="/:bee" element={<BeeDetailsPage />} />

--- a/src/Components/Navbar.js
+++ b/src/Components/Navbar.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import { NavLink } from 'react-router-dom';
 import { toggleLogin } from '../Pages/LoginPage';
+import { toggleSignup } from '../Pages/SignupPage';
 import '../Styles/navbar.scss';
 
 const nav = document.getElementsByTagName('nav');
@@ -63,7 +64,7 @@ const Navbar = () => {
             <p role="presentation" onClick={toggleLogin}>Log in</p>
           </li>
           <li>
-            <p>Sign up</p>
+            <p role="presentation" onClick={toggleSignup}>Sign up</p>
           </li>
         </ul>
       </nav>

--- a/src/Components/Navbar.js
+++ b/src/Components/Navbar.js
@@ -4,7 +4,10 @@ import { toggleLogin } from '../Pages/LoginPage';
 import { toggleSignup } from '../Pages/SignupPage';
 import '../Styles/navbar.scss';
 
-const nav = document.getElementsByTagName('nav');
+export const toggle = () => {
+  const nav = document.getElementsByTagName('nav');
+  nav[0].classList.toggle('invisible');
+};
 
 const Navbar = () => {
   const links = [
@@ -34,10 +37,6 @@ const Navbar = () => {
       text: 'Delete Bee',
     },
   ];
-
-  function toggle() {
-    nav[0].classList.toggle('invisible');
-  }
 
   return (
     <>

--- a/src/Components/Navbar.js
+++ b/src/Components/Navbar.js
@@ -1,7 +1,6 @@
 import React from 'react';
 import { NavLink } from 'react-router-dom';
 import { toggleLogin } from '../Pages/LoginPage';
-import { toggleSignup } from '../Pages/SignupPage';
 import '../Styles/navbar.scss';
 
 export const toggle = () => {
@@ -47,15 +46,14 @@ const Navbar = () => {
 
         <div className="slice" />
       </div>
-      <nav>
+      <nav className="invisible">
         <ul className="links">
           {links.map((link) => (
-            <li key={link.id} className="linkLi">
+            <li key={link.id}>
               <NavLink
                 to={link.path}
-                className={(navData) => (navData.isActive ? 'active' : 'link')}
               >
-                {link.text}
+                <p>{link.text}</p>
               </NavLink>
             </li>
           ))}
@@ -63,7 +61,7 @@ const Navbar = () => {
             <p role="presentation" onClick={toggleLogin}>Log in</p>
           </li>
           <li>
-            <p role="presentation" onClick={toggleSignup}>Sign up</p>
+            <p role="presentation">Placeholder</p>
           </li>
         </ul>
       </nav>

--- a/src/Components/Navbar.js
+++ b/src/Components/Navbar.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import { NavLink } from 'react-router-dom';
+import { toggleLogin } from '../Pages/LoginPage';
 import '../Styles/navbar.scss';
 
 const nav = document.getElementsByTagName('nav');
@@ -59,7 +60,7 @@ const Navbar = () => {
             </li>
           ))}
           <li>
-            <p>Log in</p>
+            <p role="presentation" onClick={toggleLogin}>Log in</p>
           </li>
           <li>
             <p>Sign up</p>

--- a/src/Pages/LoginPage.js
+++ b/src/Pages/LoginPage.js
@@ -10,6 +10,31 @@ export const toggleLogin = () => {
 const LoginPage = () => (
   <div id="loginPage" className="invisible">
     <div id="loginClose" role="presentation" onClick={toggleLogin}>X</div>
+    <div className="loginForm mobile">
+      <h1>Login</h1>
+      <section className="loginSection" id="loginSection">
+        <form className="LoginForm" method="post">
+          <input
+            type="text"
+            name="username"
+            id="username"
+            placeholder="Enter your username"
+            required
+            maxLength="30"
+          />
+          {/* <input
+            type="email"
+            name="email"
+            id="mail"
+            placeholder="Email address"
+            title="Please use all lower-case characters for your email address"
+            required
+          /> */}
+          <span className="error" aria-live="polite" />
+          <button type="submit" className="loginBtn">login</button>
+        </form>
+      </section>
+    </div>
   </div>
 );
 

--- a/src/Pages/LoginPage.js
+++ b/src/Pages/LoginPage.js
@@ -8,7 +8,7 @@ export const toggleLogin = () => {
 };
 
 const LoginPage = () => (
-  <div id="loginPage" className="flex">
+  <div id="loginPage" className="invisible">
     <div id="loginClose" role="presentation" onClick={toggleLogin}>X</div>
   </div>
 );

--- a/src/Pages/LoginPage.js
+++ b/src/Pages/LoginPage.js
@@ -1,4 +1,5 @@
 import '../Styles/login_page.scss';
+import { toggleSignup } from './SignupPage';
 
 export const toggleLogin = () => {
   const loginPage = document.getElementById('loginPage');
@@ -8,13 +9,18 @@ export const toggleLogin = () => {
   loginPage.classList.toggle('flex');
 };
 
+const signupToggle = () => {
+  toggleLogin();
+  toggleSignup();
+};
+
 const LoginPage = () => (
   <div id="loginPage" className="invisible">
     <div id="loginClose" role="presentation" onClick={toggleLogin}>X</div>
     <div className="loginForm mobile">
-      <h1>Login</h1>
+      <h1>Buzz In</h1>
       <section className="loginSection" id="loginSection">
-        <form className="LoginForm" method="post">
+        <form className="loginForm" method="post">
           <input
             type="text"
             name="username"
@@ -23,17 +29,12 @@ const LoginPage = () => (
             required
             maxLength="30"
           />
-          {/* <input
-            type="email"
-            name="email"
-            id="mail"
-            placeholder="Email address"
-            title="Please use all lower-case characters for your email address"
-            required
-          /> */}
           <span className="error" aria-live="polite" />
-          <button type="submit" className="loginBtn">login</button>
+          <button type="submit" className="loginBtn">Let&apos;s Go!</button>
         </form>
+        <div className="signupLink">
+          <p id="signup" role="presentation" onClick={signupToggle}>Sign Up</p>
+        </div>
       </section>
     </div>
   </div>

--- a/src/Pages/LoginPage.js
+++ b/src/Pages/LoginPage.js
@@ -1,0 +1,16 @@
+import '../Styles/login_page.scss';
+
+export const toggleLogin = () => {
+  const loginPage = document.getElementById('loginPage');
+  console.log(loginPage);
+  loginPage.classList.toggle('invisible');
+  loginPage.classList.toggle('flex');
+};
+
+const LoginPage = () => (
+  <div id="loginPage" className="flex">
+    <div id="loginClose" role="presentation" onClick={toggleLogin}>X</div>
+  </div>
+);
+
+export default LoginPage;

--- a/src/Pages/LoginPage.js
+++ b/src/Pages/LoginPage.js
@@ -2,7 +2,8 @@ import '../Styles/login_page.scss';
 
 export const toggleLogin = () => {
   const loginPage = document.getElementById('loginPage');
-  console.log(loginPage);
+  const nav = document.getElementsByTagName('nav');
+  nav[0].classList.toggle('invisible');
   loginPage.classList.toggle('invisible');
   loginPage.classList.toggle('flex');
 };

--- a/src/Pages/SignupPage.js
+++ b/src/Pages/SignupPage.js
@@ -1,0 +1,16 @@
+import '../Styles/signup_page.scss';
+
+export const toggleSignup = () => {
+  const signupPage = document.getElementById('signupPage');
+  console.log(signupPage);
+  signupPage.classList.toggle('invisible');
+  signupPage.classList.toggle('flex');
+};
+
+const SignupPage = () => (
+  <div id="signupPage" className="flex">
+    <div id="signupClose" role="presentation" onClick={toggleSignup}>X</div>
+  </div>
+);
+
+export default SignupPage;

--- a/src/Pages/SignupPage.js
+++ b/src/Pages/SignupPage.js
@@ -2,7 +2,8 @@ import '../Styles/signup_page.scss';
 
 export const toggleSignup = () => {
   const signupPage = document.getElementById('signupPage');
-  console.log(signupPage);
+  const nav = document.getElementsByTagName('nav');
+  nav[0].classList.toggle('invisible');
   signupPage.classList.toggle('invisible');
   signupPage.classList.toggle('flex');
 };

--- a/src/Pages/SignupPage.js
+++ b/src/Pages/SignupPage.js
@@ -8,9 +8,38 @@ export const toggleSignup = () => {
   signupPage.classList.toggle('flex');
 };
 
+const loginToggle = () => {
+  const loginPage = document.getElementById('loginPage');
+  const nav = document.getElementsByTagName('nav');
+  nav[0].classList.toggle('invisible');
+  loginPage.classList.toggle('invisible');
+  loginPage.classList.toggle('flex');
+  toggleSignup();
+};
+
 const SignupPage = () => (
-  <div id="signupPage" className="flex">
+  <div id="signupPage" className="invisible">
     <div id="signupClose" role="presentation" onClick={toggleSignup}>X</div>
+    <div className="loginForm mobile">
+      <h1>Sign Up</h1>
+      <section className="loginSection" id="loginSection">
+        <form className="loginForm" method="post">
+          <input
+            type="text"
+            name="username"
+            id="username"
+            placeholder="Enter your desired username"
+            required
+            maxLength="30"
+          />
+          <span className="error" aria-live="polite" />
+          <button type="submit" className="loginBtn">Sign me up!</button>
+        </form>
+        <div className="signupLink">
+          <p id="signup" role="presentation" onClick={loginToggle}>Log in</p>
+        </div>
+      </section>
+    </div>
   </div>
 );
 

--- a/src/Styles/login_page.scss
+++ b/src/Styles/login_page.scss
@@ -1,0 +1,30 @@
+#loginPage {
+  border: 1px solid red;
+  position: absolute;
+  z-index: 2;
+  width: 100%;
+  height: 100%;
+  justify-content: center;
+  align-items: center;
+  background: yellow;
+  background: rgba(255, 255, 0, 0.7);
+  backdrop-filter: blur(6px);
+}
+
+#loginClose {
+  position: absolute;
+  position: absolute;
+  top: 24px;
+  right: 41px;
+  font-size: 34px;
+  cursor: pointer;
+}
+
+.flex {
+  display: flex;
+  flex-direction: column;
+}
+
+.invisible {
+  display: none;
+}

--- a/src/Styles/login_page.scss
+++ b/src/Styles/login_page.scss
@@ -13,7 +13,6 @@
 
 #loginClose {
   position: absolute;
-  position: absolute;
   top: 24px;
   right: 41px;
   font-size: 34px;
@@ -23,7 +22,32 @@
 .loginForm {
   display: flex;
   flex-direction: column;
-  gap: 2rem;
+  gap: 1.5rem;
+  align-items: center;
+}
+
+.loginBtn {
+  background: none;
+  font-size: 24px;
+  border: 2px solid #2f4858;
+  padding: 1rem 2rem;
+}
+
+// Form
+#username {
+  font-size: 20px;
+  padding: 5px;
+}
+
+.signupLink {
+  display: flex;
+  justify-content: center;
+  margin-top: 1rem;
+}
+
+#signup {
+  cursor: pointer;
+  font-size: 19px;
 }
 
 .flex {

--- a/src/Styles/login_page.scss
+++ b/src/Styles/login_page.scss
@@ -20,6 +20,12 @@
   cursor: pointer;
 }
 
+.loginForm {
+  display: flex;
+  flex-direction: column;
+  gap: 2rem;
+}
+
 .flex {
   display: flex;
   flex-direction: column;

--- a/src/Styles/navbar.scss
+++ b/src/Styles/navbar.scss
@@ -12,17 +12,28 @@ nav {
     li {
       font-size: 34px;
       font-weight: 900;
-      padding: 1.5rem 0;
+
+      p {
+        padding: 1.5rem;
+        cursor: pointer;
+      }
 
       a,
       p {
         text-decoration: none;
         color: black;
-        margin-left: 3rem;
       }
 
-      p {
-        cursor: pointer;
+      a {
+        p {
+          width: 100%;
+          padding: 1.5rem;
+        }
+      }
+
+      .active p {
+        background-color: black;
+        color: white;
       }
     }
 

--- a/src/Styles/navbar.scss
+++ b/src/Styles/navbar.scss
@@ -60,3 +60,8 @@ nav {
 .invisible {
   display: none;
 }
+
+.flex {
+  display: flex;
+  flex-direction: column;
+}

--- a/src/Styles/signup_page.scss
+++ b/src/Styles/signup_page.scss
@@ -1,0 +1,30 @@
+#signupPage {
+  border: 1px solid red;
+  position: absolute;
+  z-index: 2;
+  width: 100%;
+  height: 100%;
+  justify-content: center;
+  align-items: center;
+  background: yellow;
+  background: rgba(255, 255, 0, 0.7);
+  backdrop-filter: blur(6px);
+}
+
+#signupClose {
+  position: absolute;
+  position: absolute;
+  top: 24px;
+  right: 41px;
+  font-size: 34px;
+  cursor: pointer;
+}
+
+.flex {
+  display: flex;
+  flex-direction: column;
+}
+
+.invisible {
+  display: none;
+}

--- a/src/Styles/signup_page.scss
+++ b/src/Styles/signup_page.scss
@@ -13,7 +13,6 @@
 
 #signupClose {
   position: absolute;
-  position: absolute;
   top: 24px;
   right: 41px;
   font-size: 34px;
@@ -27,4 +26,35 @@
 
 .invisible {
   display: none;
+}
+
+.signupForm {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+  align-items: center;
+}
+
+.signupBtn {
+  background: none;
+  font-size: 24px;
+  border: 2px solid #2f4858;
+  padding: 1rem 2rem;
+}
+
+// Form
+#username {
+  font-size: 20px;
+  padding: 5px;
+}
+
+.loginLink {
+  display: flex;
+  justify-content: center;
+  margin-top: 1rem;
+}
+
+#login {
+  cursor: pointer;
+  font-size: 19px;
 }


### PR DESCRIPTION
Here's the buzz on this pull request:

- Navbar now defaults to a closed position

- Placeholder LI has been set up in the navbar to reserve spacing (and provide visual) of the future LI that will replace it when we institute state (e.g. signout or something similar for when a user is signed in)

- Navbar now holds an active hover effect when a user is on a specific page
  

- The navbar now has a selection for login which will display a login page overlay on top of the screen


- When a user clicks on signup, the login page will be replaced with the sign-up page. If the user already has an account then they will have a path to return to login


- Using the close button on either form will return the user back to the navigation bar where they originally selected login

  
![image](https://user-images.githubusercontent.com/92178070/184403805-e0a8eda7-c210-4bdb-9afc-4dd4a5166081.png)![image](https://user-images.githubusercontent.com/92178070/184404033-b484a1d0-a064-4065-be7f-20cbe45c75ab.png) ![image](https://user-images.githubusercontent.com/92178070/184404272-a4c0dcd6-26e0-4906-9e54-a0e0bce6f90a.png)

